### PR TITLE
Use the deploy 'rails_env' to set RAILS_ENV and RACK_ENV

### DIFF
--- a/recipes/deploy.rb
+++ b/recipes/deploy.rb
@@ -2,7 +2,7 @@ node[:deploy].each do |application, deploy|
   if deploy['sidekiq']
     sidekiq_config = deploy['sidekiq']
     release_path = ::File.join(deploy[:deploy_to], 'current')
-    start_command = sidekiq_config['start_command'] || "bundle exec sidekiq -d -l log/sidekiq.log"
+    start_command = sidekiq_config['start_command'] || "bundle exec sidekiq -l log/sidekiq.log"
     env = deploy['environment_variables'] || {}
     rails_env = sidekiq_config['rails_env'] || deploy[:rails_env]
 

--- a/recipes/deploy.rb
+++ b/recipes/deploy.rb
@@ -2,8 +2,9 @@ node[:deploy].each do |application, deploy|
   if deploy['sidekiq']
     sidekiq_config = deploy['sidekiq']
     release_path = ::File.join(deploy[:deploy_to], 'current')
-    start_command = sidekiq_config['start_command'] || "bundle exec sidekiq -e production -C config/sidekiq.yml -r ./config/boot.rb 2>&1 >> log/sidekiq.log"
+    start_command = sidekiq_config['start_command'] || "bundle exec sidekiq -d -l log/sidekiq.log"
     env = deploy['environment_variables'] || {}
+    rails_env = sidekiq_config['rails_env'] || deploy[:rails_env]
 
     template "setup sidekiq.conf" do
       path "/etc/init/sidekiq-#{application}.conf"
@@ -18,6 +19,7 @@ node[:deploy].each do |application, deploy|
         release_path: release_path,
         start_command: start_command,
         env: env,
+        rails_env: rails_env,
       })
     end
 

--- a/templates/default/sidekiq.conf.erb
+++ b/templates/default/sidekiq.conf.erb
@@ -32,6 +32,10 @@ chdir "<%= @release_path %>"
 <% @env.each do |k,v| %>
 env <%= k %>=<%= (v || '').to_s.gsub('"', '\\"') %>
 <% end %>
+<% if @rails_env %>
+env RAILS_ENV=<%= @rails_env %>
+env RACK_ENV=<%= @rails_env %>
+<% end %>
 
 script
   exec <%= @start_command %>


### PR DESCRIPTION
OpsWorks sets deploy[:rails_env] to the configured rails environment for
a Rails app and uses this when launching Unicorn. Sidekiq should also
have access to and use this variable by default.

This also provides a node["deploy"][app_name]["rails_env"] option to
override the app's environment setting.

Finally the default "start_command" has been simplified to take
advantage of the default settings.